### PR TITLE
Fix modal dialogs z-index

### DIFF
--- a/src/main/resources/less/admin-lte/bootstrap/variables.less
+++ b/src/main/resources/less/admin-lte/bootstrap/variables.less
@@ -269,14 +269,15 @@
 // of components dependent on the z-axis and are designed to all work together.
 //
 // Note: These variables are not generated into the Customizer.
+// admin-theme: values lowered by 100 to workaround primefaces dialog z-index ordering
 
-@zindex-navbar: 1000;
-@zindex-dropdown: 1000;
-@zindex-popover: 1060;
-@zindex-tooltip: 1070;
-@zindex-navbar-fixed: 1030;
-@zindex-modal-background: 1040;
-@zindex-modal: 1050;
+@zindex-navbar: 900;
+@zindex-dropdown: 900;
+@zindex-popover: 960;
+@zindex-tooltip: 970;
+@zindex-navbar-fixed: 930;
+@zindex-modal-background: 940;
+@zindex-modal: 950;
 
 //== Media queries breakpoints
 //

--- a/src/main/resources/less/primefaces-admin/components/autocomplete.less
+++ b/src/main/resources/less/primefaces-admin/components/autocomplete.less
@@ -166,7 +166,6 @@ button.ui-autocomplete-dropdown  span.ui-icon-triangle-1-s {
 }
 
 div.ui-autocomplete-itemtip {
-    z-index: (@dialog-zindex + 1)important;
     width: auto!important;
 }
 

--- a/src/main/resources/less/primefaces-admin/components/calendar.less
+++ b/src/main/resources/less/primefaces-admin/components/calendar.less
@@ -1,6 +1,5 @@
 /*Datepicker*/
 body .ui-datepicker {
-  z-index: @calendar-zindex!important;
   padding: 0;
   border: none;
 

--- a/src/main/resources/less/primefaces-admin/components/dialog.less
+++ b/src/main/resources/less/primefaces-admin/components/dialog.less
@@ -18,7 +18,6 @@ body .ui-dialog.ui-widget-content, body .ui-dialog {
     overflow: visible;
     border: 0 none;
     .box-shadow(0 1px 4px rgba(0, 0, 0, 0.75));
-    z-index: @dialog-zindex!important;//we need the important because primefaces add z-index directly to component style
 
     &#adminStatusDialog {//ajaxStatus dialog must have higher z-index
                          z-index: 9999!important;
@@ -30,10 +29,6 @@ body .ui-dialog.ui-widget-content, body .ui-dialog {
     }
     a.ui-dialog-titlebar-icon {
         padding: 1px !important;
-    }
-
-    &.ui-dialog-maximized {
-        z-index: @dialog-zindex!important;
     }
 
     .ui-dialog-titlebar {

--- a/src/main/resources/less/primefaces-admin/components/dialog.less
+++ b/src/main/resources/less/primefaces-admin/components/dialog.less
@@ -174,14 +174,6 @@ a.ui-dialog-titlebar-icon {
     box-shadow: none !important;
 }
 
-body .ui-overlaypanel {
-    z-index: @dialog-zindex!important;
-}
-
-.ui-selectcheckboxmenu-panel, .ui-selectonemenu-panel, .ui-autocomplete-panel {
-    z-index: (@dialog-zindex+1)!important;
-}
-
 .dialog-solid(@color) {
     border-top: 0;
     .ui-dialog-titlebar {


### PR DESCRIPTION
Related to issue https://github.com/adminfaces/admin-template/issues/119 : lower values of bootstrap z-index variables by 100, making primefaces dialog free to use the 1000 values space. Also removes the z-index !important that have been placed in the previous workaround.

More extensive testing welcome.